### PR TITLE
Fix a typo in VSLite.R

### DIFF
--- a/R/VSLite.R
+++ b/R/VSLite.R
@@ -116,14 +116,15 @@ VSLite <- function(syear,eyear,phi,T,P,
     # to the next year:
     width[nyrs] <- sum(Gr[startmo:12,nyrs])+sum(rowMeans(Gr[1:endmo,]));
   }
-  
+
   # Simulated proxy series standardized width:
-  trw <- t((width-mean(width))/sd(width)); 
+  trw <- t((width-mean(width))/sd(width));
+  trw_org <- trw*sd(width)+mean(width);
 
   #############################################################################
   # Return output:
   out <- list(trw = trw, gT = gT, gM = gM, gE = gE, M = M, potEv = potEv,
-              sample.mean.width = mean(width), sample.std.width = sd(width))
+              sample.mean.width = mean(width), sample.std.width = sd(width), trw_org=trw_org)
   return(out)
 
 }

--- a/R/VSLite.R
+++ b/R/VSLite.R
@@ -119,7 +119,7 @@ VSLite <- function(syear,eyear,phi,T,P,
 
   # Simulated proxy series standardized width:
   trw <- t((width-mean(width))/sd(width));
-  trw_org <- trw*sd(width)+mean(width);
+  trw_org <- width;
 
   #############################################################################
   # Return output:

--- a/R/VSLite.R
+++ b/R/VSLite.R
@@ -110,7 +110,7 @@ VSLite <- function(syear,eyear,phi,T,P,
     startmo <- 7+I_0; # (eg. I_0 = -4 in SH corresponds to starting integration in March of cyear)
     endmo <- I_f-6; # (eg. I_f = 12 in SH corresponds to ending integraion in June of next year)
     for (cyear in 1:(nyrs-1)){
-      width(cyear) <- sum(Gr[startmo:12,cyear]) + sum(Gr[1:endmo,cyear+1]);
+      width[cyear] <- sum(Gr[startmo:12,cyear]) + sum(Gr[1:endmo,cyear+1]);
     }
     # use average of growth data across modeled years to estimate last year's growth due
     # to the next year:

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # VSLiteR
 port of the VS-Lite model and associated functions, including parameter estimation, to R.
+
+
+# How to install
+In `R`:
+```R
+install.packages("devtools")
+devtools::install_github("fzhu2e/VSLiteR")
+```


### PR DESCRIPTION
Hi Suz,

First, thanks for your fantastic work on VSLite.

I was trying to use this R package, and I think there is a typo in `VSLite.R`:
https://github.com/suztolwinskiward/VSLiteR/blob/b96bb4b668326e8b9cfded3ce23badc28b02059b/R/VSLite.R#L113

where ` width(cyear) ` should be `width[cyear]`. Otherwise, the code will break when `phi < 0`.

This pull request is just to simply fix that typo.

Best,
Feng